### PR TITLE
Fix errant character in ch12.tex.

### DIFF
--- a/ch12.tex
+++ b/ch12.tex
@@ -146,7 +146,7 @@ current user program.
 
 This raises an interesting question: ``Why are the kernel mode
 and user mode floating point
-exceptions handled slightly di£ferently?''
+exceptions handled slightly differently?''
 
 
 \sbs{User Mode Traps}


### PR DESCRIPTION
This was an invalid UTF-8 sequence that prevented
`pdflatex` from typesetting the document.  It also
appeared to be an error; something that looked
like a Pound symbol (as in, the British currency)
should have been an ASCII lowercase letter f).

Signed-off-by: Dan Cross <crossd@gmail.com>